### PR TITLE
Added Mindfulness Policy for ACO/AMO

### DIFF
--- a/Mindfulness-Policy.md
+++ b/Mindfulness-Policy.md
@@ -1,0 +1,24 @@
+# Mindfulness Policy
+
+We entertain the idea that this planet is a living organism, a holistic system – made of many decentralised parts - that strives for balance and sustainability from chaos, in order to create symbiotic, more efficient & less intrusive forms of life.
+#
+**We value life over profit**
+In order to live in harmony with this planet, we will always **favour**:
+
+* **Building** on sovereign grade censorship resistant systems, offering data- & **self-sovereignty** for good actors, over centralized, censorable systems. 
+* **Creating a harmonious habitat**, blending in and supporting synergies with the environment, over elbow and zero sum games.
+* **Complementing**, over construing, the **environment and individual**.
+* **Embracing** new technologies & **fresh thought** processes, over conserving faulty systems
+* **Open source ideas** and build loyalty coalitions and teams (infosets/Holons), over proprietary code and hierarchical companies.
+* **Preserving**, over extracting, **resources** from the environment or individuals. Growing networks, over enterprises.
+#
+* **Cooperating**, over competing.
+* **Love**, over fear of change.
+* **Sustainability** over quick profit
+* **Solutioning**, over discussing problems.
+* Game B over Game A
+## Appendix
+***This Mindfulness Policy is the primer for the organisation charter***
+
+1.  It's recommended as the **only obligation** for members of any Autonomous Maker/Creator Organistaion (AMO/ACO) to read the Policy and Charter carefully and subsequently sign and adhere to it.
+2. Changing the Charter or Policy is possible if all founding members see it necessary and can be done only prior to the **Genesis Event** of any AMO/ACO.

--- a/README.md
+++ b/README.md
@@ -15,3 +15,6 @@ SecretDecks® is a brand that is the seed catalysing a new kind of endeavour, ca
 [1. Smart Contract Draft](https://github.com/SecretDecks/Documentation/blob/main/SmartContract-Drafts.md) 
 
 [2. Token Design Kickoff](https://github.com/SecretDecks/Documentation/blob/main/TokenDesign-Kickoff-Doc.md)
+
+[3. Mindfulness Policy](https://github.com/DanM3rcurius/Documentation/blob/main/Mindfulness-Policy.md)
+


### PR DESCRIPTION
added [mindfulness-policy.md](https://github.com/DanM3rcurius/Documentation/blob/main/Mindfulness-Policy.md) for the 
Autonomous Maker/Creator Organisation (ACO/AMO) and updated readme overview with said document